### PR TITLE
 <a> without a 'href' caused a crash 

### DIFF
--- a/html2markdown.py
+++ b/html2markdown.py
@@ -187,6 +187,8 @@ def _markdownify(tag, _listType=None, _blockQuote=False, _listIndex=1):
 				tag.string = '[%s](%s%s)' % (BeautifulSoup(unicode(tag), 'html.parser').string,
 					tag.get('href', ''),
 					title)
+			elif tag.string == tag.get('href') == tag.get('title'):
+				tag.string = '[]()'
 			else:
 				# ! FIXME: hack
 				tag.string = '<<<FLOATING LINK: %s>>>' % tag.string

--- a/html2markdown.py
+++ b/html2markdown.py
@@ -180,12 +180,12 @@ def _markdownify(tag, _listType=None, _blockQuote=False, _listIndex=1):
 			# process children first
 			for child in children:
 				_markdownify(child)
-			if tag.string != tag['href'] or tag.has_attr('title'):
+			if tag.string != tag.get('href') or tag.has_attr('title'):
 				title = ''
 				if tag.has_attr('title') and tag['title']:
 					title = ' "%s"' % tag['title']
 				tag.string = '[%s](%s%s)' % (BeautifulSoup(unicode(tag), 'html.parser').string,
-					tag['href'],
+					tag.get('href', ''),
 					title)
 			else:
 				# ! FIXME: hack

--- a/html2markdown.py
+++ b/html2markdown.py
@@ -187,7 +187,7 @@ def _markdownify(tag, _listType=None, _blockQuote=False, _listIndex=1):
 				tag.string = '[%s](%s%s)' % (BeautifulSoup(unicode(tag), 'html.parser').string,
 					tag.get('href', ''),
 					title)
-			elif tag.string == tag.get('href') == tag.get('title'):
+			elif tag.string == tag.get('href') == tag.get('title') == None:
 				tag.string = '[]()'
 			else:
 				# ! FIXME: hack

--- a/tests.py
+++ b/tests.py
@@ -52,7 +52,8 @@ class TestEscaping(unittest.TestCase):
 class TestTags(unittest.TestCase):
 
 	genericStr = '<div><p>asdf</p></div><h2>Test</h2><pre><code>Here is some code</code></pre>'
-
+	problematic_a_string_1 = "before <a>test</a> after"
+	problematic_a_string_2 = "before <a title='test_title'>test</a> after"
 	def test_h2(self):
 		mdStr = html2markdown.convert(self.genericStr)
 		reconstructedStr = markdown.markdown(mdStr)
@@ -62,6 +63,13 @@ class TestTags(unittest.TestCase):
 
 		self.assertEqual(childTags[1].name, 'h2')
 		self.assertEqual(childTags[1].string, 'Test')
+
+	def test_a(self):
+		mdStr = html2markdown.convert(self.problematic_a_string_1)
+		assert mdStr == "before [test]() after"
+
+		mdStr = html2markdown.convert(self.problematic_a_string_2)
+		assert mdStr == 'before [test]( "test_title") after'
 
 if __name__ == '__main__':
 	unittest.main()

--- a/tests.py
+++ b/tests.py
@@ -54,6 +54,7 @@ class TestTags(unittest.TestCase):
 	genericStr = '<div><p>asdf</p></div><h2>Test</h2><pre><code>Here is some code</code></pre>'
 	problematic_a_string_1 = "before <a>test</a> after"
 	problematic_a_string_2 = "before <a title='test_title'>test</a> after"
+	problematic_a_string_3 = "<a></a>"
 	def test_h2(self):
 		mdStr = html2markdown.convert(self.genericStr)
 		reconstructedStr = markdown.markdown(mdStr)
@@ -70,6 +71,9 @@ class TestTags(unittest.TestCase):
 
 		mdStr = html2markdown.convert(self.problematic_a_string_2)
 		assert mdStr == 'before [test]( "test_title") after'
+
+		mdStr = html2markdown.convert(self.problematic_a_string_3)
+		assert mdStr == '[]()'
 
 if __name__ == '__main__':
 	unittest.main()

--- a/tests.py
+++ b/tests.py
@@ -55,6 +55,7 @@ class TestTags(unittest.TestCase):
 	problematic_a_string_1 = "before <a>test</a> after"
 	problematic_a_string_2 = "before <a title='test_title'>test</a> after"
 	problematic_a_string_3 = "<a></a>"
+	problematic_a_string_4 = "<a href='test' title='test'>test</a>"
 	def test_h2(self):
 		mdStr = html2markdown.convert(self.genericStr)
 		reconstructedStr = markdown.markdown(mdStr)
@@ -74,6 +75,9 @@ class TestTags(unittest.TestCase):
 
 		mdStr = html2markdown.convert(self.problematic_a_string_3)
 		assert mdStr == '[]()'
+
+		mdStr = html2markdown.convert(self.problematic_a_string_4)
+		assert mdStr == '[test](test "test")'
 
 if __name__ == '__main__':
 	unittest.main()


### PR DESCRIPTION
Attempt to convert a string which contains **\<a>** tag without a **href** attribute caused a crash(*KeyError*).
