### PR TITLE
add support for plain table conversion

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -59,6 +59,17 @@ class TestGenericTags(unittest.TestCase):
 				'Tag: {}. Conversion: {}'.format(tag, mdStr)
 			)
 
+	def test_table_tag(self):
+		"""<table> tags should be converted. columns should preserve width across rows.
+			td|th tag attr style="text-align: [left|center|right]" should be observed
+		"""
+		testStr = '<table><thead><tr><th><b>One</b></th><th style="text-align: right">Two</th></tr></thead>' \
+				  '<tbody><tr><td>Line 1</td><td>Second Line</td></tr></tbody></table>'
+		expectedStr = u'| One    |         Two |\n| ------ | -----------:|\n| Line 1 | Second Line |'
+		mdStr = html2markdown.convert(testStr)
+		self.assertEqual(mdStr, expectedStr)
+
+
 class TestEscaping(unittest.TestCase):
 
 	escapableChars = r'\`*_{}[]()#+-.!'


### PR DESCRIPTION
Hi,
First 'pull-request' in quite a long, not sure how this works.
Basically suggesting a non-recursive way of markdownifying an html table with plain output in each cell.
For my own purposed I aimed at preserving column widths across rows and observing any given ``style="text-align: xxx"`` cell attribute.
Cell contents are rendered as plain tag.text but I believe you can easily improve this to deliver markdownified contents.