### PR TITLE
Feat: fenced code blocks

### DIFF
--- a/html2markdown.py
+++ b/html2markdown.py
@@ -213,7 +213,7 @@ def _markdownify(tag, _listType=None, _blockQuote=False, _listIndex=1):
 		tag.string = '\n---\n'
 		tag.unwrap()
 	elif tag.name == 'pre':
-                tag.insert_before('\n\n```\n')
+		tag.insert_after('\n\n```\n')
 		tag.insert_after('\n```\n\n')
 		if tag.code:
 			if not _supportedAttrs(tag.code):

--- a/html2markdown.py
+++ b/html2markdown.py
@@ -213,8 +213,8 @@ def _markdownify(tag, _listType=None, _blockQuote=False, _listIndex=1):
 		tag.string = '\n---\n'
 		tag.unwrap()
 	elif tag.name == 'pre':
-		tag.insert_before('\n\n')
-		tag.insert_after('\n\n')
+                tag.insert_before('\n\n```\n')
+		tag.insert_after('\n```\n\n')
 		if tag.code:
 			if not _supportedAttrs(tag.code):
 				return
@@ -233,7 +233,6 @@ def _markdownify(tag, _listType=None, _blockQuote=False, _listIndex=1):
 				lines.pop()
 			for i,line in enumerate(lines):
 				line = line.replace(u'\xa0', ' ')
-				lines[i] = '    %s' % line
 			tag.replace_with(BeautifulSoup('\n'.join(lines), 'html.parser'))
 		return
 	elif tag.name == 'code':

--- a/html2markdown.py
+++ b/html2markdown.py
@@ -213,7 +213,7 @@ def _markdownify(tag, _listType=None, _blockQuote=False, _listIndex=1):
 		tag.string = '\n---\n'
 		tag.unwrap()
 	elif tag.name == 'pre':
-		tag.insert_after('\n\n```\n')
+		tag.insert_before('\n\n```\n')
 		tag.insert_after('\n```\n\n')
 		if tag.code:
 			if not _supportedAttrs(tag.code):


### PR DESCRIPTION
Changes the representation of `<pre><code>` to **fenced code blocks** instead of indented code blocks in Markdown.

Fenced code blocks allow for user-friendly addition of _language syntax_, e.g.:

    ```python
    print("hello")
    ```

[Syntax highlighting](https://www.markdownguide.org/extended-syntax/#fenced-code-blocks) for these types of fenced code blocks is today widely available and make code snippets more legible.

I therefore suggest to replace this as the default rendering of `<pre><code>`.